### PR TITLE
Rename setup program to startup and reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Scripts to control Bigger Reactors turbines with ComputerCraft/CC:Tweaked.
 - `turbine_control.lua`: wired version. Use only when turbines are directly connected to the computer with no modem.
 - `setup.lua`: interactive script that downloads the correct program depending on the connection type (wired or wireless).
 
+## Setup
+
+To launch the setup, run `pastebin run eHsmkvYk`.
+

--- a/setup.lua
+++ b/setup.lua
@@ -3,32 +3,43 @@
 
 local BASE_URL = "https://raw.githubusercontent.com/MystereFire/biggerreactor_turbine/main/"
 
-local function download(file)
-    local url = BASE_URL .. file
-    print("Downloading " .. file .. "...")
-    if not shell.run("wget", url, file) then
+local function download(remote, target)
+    target = target or remote
+    local url = BASE_URL .. remote
+    print("Downloading " .. remote .. " as " .. target .. "...")
+    if not shell.run("wget", url, target) then
         print("Failed to download: " .. url)
     else
-        print("Installed: " .. file)
+        print("Installed: " .. target)
     end
 end
 
+term.clear()
+term.setCursorPos(1, 1)
 print("Connection type? (wired/wireless)")
 local mode = read():lower()
+term.clear()
+term.setCursorPos(1, 1)
 
 if mode == "wired" or mode == "w" then
-    download("turbine_control.lua")
+    download("turbine_control.lua", "startup")
 elseif mode == "wireless" or mode == "wl" then
     print("Emitter or receiver? (e/r)")
     local role = read():lower()
+    term.clear()
+    term.setCursorPos(1, 1)
     if role == "e" or role == "emitter" then
-        download("sender.lua")
+        download("sender.lua", "startup")
     elseif role == "r" or role == "receiver" then
-        download("receiver.lua")
+        download("receiver.lua", "startup")
     else
         print("Invalid choice: " .. role)
     end
 else
     print("Unknown mode: " .. mode)
 end
+
+print("Rebooting...")
+sleep(1)
+os.reboot()
 


### PR DESCRIPTION
## Summary
- Save installed program as `startup` and clear the terminal between prompts.
- Reboot the computer at the end of the setup process.
- Document running the setup via `pastebin run eHsmkvYk`.

## Testing
- `lua -p setup.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892761c2710832fab1f91718fdcab00