### PR TITLE
Set turbine vent mode to exhaust when enabling

### DIFF
--- a/sender.lua
+++ b/sender.lua
@@ -54,6 +54,9 @@ local function toggleTurbine(t)
     pcall(function()
         t.p.setActive(t.auto)
         t.p.setCoilEngaged(t.auto)
+        if t.auto and t.p.setVentMode then
+            t.p.setVentMode('vent_all')
+        end
     end)
 end
 
@@ -64,6 +67,9 @@ local function toggleAll()
         pcall(function()
             t.p.setActive(allState)
             t.p.setCoilEngaged(allState)
+            if allState and t.p.setVentMode then
+                t.p.setVentMode('vent_all')
+            end
         end)
     end
 end


### PR DESCRIPTION
## Summary
- Set vent mode to `vent_all` whenever turbines are enabled individually or in bulk

## Testing
- `luac -p sender.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68950e587bf0832fb7e006163c98c494